### PR TITLE
Upgrade actions/checkout to v4 in GitHub workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-tags: true
       - uses: bazel-contrib/setup-bazel@0.8.5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: bazel-contrib/setup-bazel@0.8.5
         with:
           bazelisk-version: 1.x


### PR DESCRIPTION
## Summary
Updated the `actions/checkout` action from v3 to v4 across all GitHub workflows to use the latest version of this commonly-used action.

## Changes
- Upgraded `actions/checkout` from v3 to v4 in `.github/workflows/release.yml`
- Upgraded `actions/checkout` from v3 to v4 in `.github/workflows/tests.yml`

## Details
This update ensures the workflows use the latest stable version of the checkout action, which includes performance improvements, bug fixes, and security updates. The v4 release maintains backward compatibility with existing workflow configurations.

https://claude.ai/code/session_01F6yUazFnuvj2PdeGxYp1Z1