### PR TITLE
Fix release checkout failure with tag-triggered workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
       - uses: bazel-contrib/setup-bazel@0.8.5
         with:
           bazelisk-version: 1.x


### PR DESCRIPTION
## Summary
- Replace `fetch-tags: true` with `fetch-depth: 0` in the release workflow checkout step
- Fixes the `Cannot fetch both <sha> and refs/tags/<tag> to refs/tags/<tag>` error that occurs when `fetch-tags: true` is used in a tag-triggered workflow

## Details
The `fetch-tags` option in `actions/checkout@v4` conflicts with tag-triggered workflows. When a tag push triggers the release workflow, the checkout action tries to fetch both the commit SHA and the tag ref to the same destination, causing a git error (exit code 128).

Using `fetch-depth: 0` (full clone) includes all tags without the conflict, so the `validate tag` step can still compare against previous tags.

## Test plan
- [ ] Push a new semver tag (e.g. `v1.0.2`) and verify the release workflow completes successfully
- [ ] Verify the GitHub release is created with auto-generated release notes

https://claude.ai/code/session_01F6yUazFnuvj2PdeGxYp1Z1